### PR TITLE
youtube: Handle disabled comment sections gracefully

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2455,8 +2455,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             session_token = bytes(session_token, 'ascii').decode('unicode-escape')
 
             data = json.loads(find_value(polymer_webpage, 'var ytInitialData = ', 0, '};') + '}')
-            ncd = next(search_dict(data, 'nextContinuationData'))
-            continuations = [(ncd['continuation'], ncd['clickTrackingParams'])]
+            try:
+                ncd = next(search_dict(data, 'nextContinuationData'))
+                continuations = [(ncd['continuation'], ncd['clickTrackingParams'])]
+            # Handle videos where comments have been disabled entirely
+            except StopIteration:
+                continuations = []
 
             def get_continuation(continuation, itct, session_token, replies=False):
 


### PR DESCRIPTION
* Handle exception thrown by next() when there is no
  nextContinuationData due to a video having it's comment section
  disabled.

Exception being thrown was:

```ERROR: An extractor error has occurred. (caused by StopIteration()); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/home/clayne/git/youtube-dl-1/youtube_dl/extractor/common.py", line 533, in extract
    ie_result = self._real_extract(url)
  File "/home/clayne/git/youtube-dl-1/youtube_dl/extractor/youtube.py", line 2458, in _real_extract
    ncd = next(search_dict(data, 'nextContinuationData'))
StopIteration
Traceback (most recent call last):
  File "/home/clayne/git/youtube-dl-1/youtube_dl/extractor/common.py", line 533, in extract
    ie_result = self._real_extract(url)
  File "/home/clayne/git/youtube-dl-1/youtube_dl/extractor/youtube.py", line 2458, in _real_extract
    ncd = next(search_dict(data, 'nextContinuationData'))
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/clayne/git/youtube-dl-1/youtube_dl/YoutubeDL.py", line 804, in wrapper
    return func(self, *args, **kwargs)
  File "/home/clayne/git/youtube-dl-1/youtube_dl/YoutubeDL.py", line 825, in __extract_info
    ie_result = ie.extract(url)
  File "/home/clayne/git/youtube-dl-1/youtube_dl/extractor/common.py", line 546, in extract
    raise ExtractorError('An extractor error has occurred.', cause=e)
youtube_dl.utils.ExtractorError: An extractor error has occurred. (caused by StopIteration()); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.```